### PR TITLE
TerraformでGKEクラスタの構成

### DIFF
--- a/k8s/goapi.yml
+++ b/k8s/goapi.yml
@@ -27,9 +27,14 @@ spec:
       labels:
         app: goapi
     spec:
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
       containers:
         - name: goapi
-          image: wakabaseisei/goapi:latest
+          image: asia.gcr.io/run-app-341001/goapi:latest
           resources:
             limits:
               memory: "128Mi"

--- a/k8s/mysql-statefulset.yml
+++ b/k8s/mysql-statefulset.yml
@@ -16,6 +16,10 @@ spec:
       initContainers:
         - name: init-mysql
           image: mysql@sha256:92ad1d7e3f8eb7e67d35bf251912fb7cd12676a601dc90b6beb1aece7c1f5073
+          resources:
+            requests:
+              cpu: 15m
+              memory: 100Mi
           command:
             - bash
             - "-c"
@@ -43,6 +47,10 @@ spec:
               mountPath: /mnt/initdb
         - name: clone-mysql
           image: gcr.io/google-samples/xtrabackup:1.0
+          resources:
+            requests:
+              cpu: 15m
+              memory: 100Mi
           command:
             - bash
             - "-c"
@@ -97,8 +105,8 @@ spec:
               mountPath: /docker-entrypoint-initdb.d
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 15m
+              memory: 100Mi
           livenessProbe:
             exec:
               command:
@@ -180,7 +188,7 @@ spec:
               mountPath: /etc/mysql/conf.d
           resources:
             requests:
-              cpu: 100m
+              cpu: 15m
               memory: 100Mi
       volumes:
         - name: conf
@@ -197,4 +205,4 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 5Gi
+            storage: 1Gi

--- a/k8s/namespace.yml
+++ b/k8s/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: develop

--- a/k8s/node-cli.yml
+++ b/k8s/node-cli.yml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: node
-          image: wakabaseisei/reactapp:latest
+          image: asia.gcr.io/run-app-341001/reactapp:latest
           resources:
             limits:
               memory: "128Mi"

--- a/k8s/role-rolebinding.yml
+++ b/k8s/role-rolebinding.yml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  # namespace: develop
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]  
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-readers
+  # namespace: develop
+subjects:
+  - kind: User
+    name: wakababoxing@gmail.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/storageClass.yml
+++ b/k8s/storageClass.yml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: slow
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/prod/.terraform.lock.hcl
+++ b/terraform/prod/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.10.0"
+  hashes = [
+    "h1:VRv6ISPlBo6ImYBAMyd5wJyhrptX3jBvESpVCbrzV+I=",
+    "zh:007f591c02afb6228b81ff4d6325170664b45df56b4af74587f3230d6675f21c",
+    "zh:017943b592f959998855d2c664778da03f9319c3c117dabbe61c644bf7cfb64e",
+    "zh:0690b05c112e12bb5d2e69d0515ef6c0b330469e99fcb79a34790f105d988c2c",
+    "zh:07029ea70670b66ffe85ea9164e7ded98ca78a89deda9aab98f4bd0b810716cf",
+    "zh:0b2716d9e3fd0fb7c32f1c12636a20d0efff81fa6968e027e2b0e76f14ace71f",
+    "zh:448bfc0646072bab70e932bdb91cc7c99379f771c8c668ee04895e1edc195972",
+    "zh:877efd64688693a49df8591ec2487598faccbbe048787869b86c984a0943dbfb",
+    "zh:99f092f81a22a6e23c42f0d0f448ae56391c252edde4d8162d759e4dd130eb93",
+    "zh:c21f7e31b799b95819561e7c345a25e6f240ccc80c29de073724d0e9457ff293",
+    "zh:e380365592434f2c084b05420b7c234f81a3500ded432c7499742558b2f7f9d1",
+    "zh:f53b6c71b62de7912283f63064086ed7ee8bdef6142007cc0719aa1f6211b5ea",
+  ]
+}

--- a/terraform/prod/cluster.tf
+++ b/terraform/prod/cluster.tf
@@ -1,0 +1,40 @@
+resource "google_container_cluster" "primary" {
+  name     = "my-gke-cluster"
+  location = var.location
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "my-gke-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = 1
+
+  node_config {
+    machine_type = "e2-medium"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
+resource "google_container_node_pool" "primary_preemptible_nodes" {
+  name       = "my-gke-preemptible-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = 1
+
+  node_config {
+    preemptible  = true
+    machine_type = "e2-medium"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}

--- a/terraform/prod/iam.tf
+++ b/terraform/prod/iam.tf
@@ -1,0 +1,5 @@
+resource "google_project_iam_member" "project" {
+  project = "run-app-341001"
+  role    = "roles/viewer"
+  member  = "user:wakababoxing@gmail.com"
+}

--- a/terraform/prod/iam.tf
+++ b/terraform/prod/iam.tf
@@ -3,3 +3,9 @@ resource "google_project_iam_member" "project" {
   role    = "roles/viewer"
   member  = "user:wakababoxing@gmail.com"
 }
+
+resource "google_project_iam_member" "project_cluster" {
+  project = "run-app-341001"
+  role    = "roles/container.developer"
+  member  = "user:wakababoxing@gmail.com"
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project     = "run-app-341001"
+  region      = "asia-northeast1"
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,4 +1,5 @@
 provider "google" {
-  project     = "run-app-341001"
-  region      = "asia-northeast1"
+  project = "run-app-341001"
+  region  = "asia-northeast1"
+  zone    = "asia-northeast1-a"
 }

--- a/terraform/prod/vars.tf
+++ b/terraform/prod/vars.tf
@@ -1,0 +1,3 @@
+variable "location" {
+  default = "asia-northeast1-a"
+}


### PR DESCRIPTION
# 概要
* ノードプールを2つ作成して、オンデマンドなノードとプリエンプティブなノード1つずつの構成にしました
プリエンプティブなノードには、APIのPodだけが配置されるようにして、MySQL用のPodとフロントエンドのPodはオンデマンドなノードにのみ配置されるように構成(APIは、オンデマンドにも配置されることもある)
* 永続ディスクの動的プロビジョニングがされるように設定ファイルを変更
*MySQL用のコンテナへのリソースの割り当て(CPU・メモリ)の調整